### PR TITLE
Fix a type error in the TranslationsList component

### DIFF
--- a/assets/components/TranslationsList.vue
+++ b/assets/components/TranslationsList.vue
@@ -167,7 +167,7 @@ export default {
         }
         const search = this.search.toLowerCase().trim();
         for (const language of this.languages) {
-          if (sourceMessage.languages[language.id] !== null &&
+          if (sourceMessage.languages[language.id] &&
             sourceMessage.languages[language.id].toLowerCase().trim().includes(search)) {
             return true;
           }


### PR DESCRIPTION
There was a type error in the filterSourceMessages() method of the TranslationsList.vue component that several users complained about. As it turned out sourceMessage.languages[language.id] can sometimes be undefined but in the if statement it was only compared to null which caused the if statement to evaluate to true because undefined is not null. Which in its turn caused a call to the toLowerCase() method of undefined.