### PR TITLE
Support table creation w/o primary key

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -23,6 +23,11 @@ class Install extends Migration
             $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
         }
 
+        // Support table creation without primary key when sql_require_primary_key
+        // is enabled (like on DigitalOcean Managed Databases)
+        // https://docs.digitalocean.com/products/databases/mysql/how-to/create-primary-keys/
+        $this->execute('SET SESSION sql_require_primary_key = 0');
+
         $this->createTable(
             '{{%source_message}}',
             [

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -26,7 +26,9 @@ class Install extends Migration
         // Support table creation without primary key when sql_require_primary_key
         // is enabled (like on DigitalOcean Managed Databases)
         // https://docs.digitalocean.com/products/databases/mysql/how-to/create-primary-keys/
-        $this->execute('SET SESSION sql_require_primary_key = 0');
+        if ($this->db->driverName === 'mysql') {
+            $this->execute('SET SESSION sql_require_primary_key = 0');
+        }
 
         $this->createTable(
             '{{%source_message}}',


### PR DESCRIPTION
This disables the `sql_require_primary_key` setting (which is enabled by default on DigitalOcean Managed Databases) in advance of table creation so that the `createTable` for the `message` table doesn't have a fatal error like this:

```
General error: 3750 Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set. Add a primary key to the table or unset this variable to avoid this message. Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.
The SQL being executed was: CREATE TABLE `message` (
  `id` int(11) NOT NULL,
  `dateCreated` datetime(0) NOT NULL,
  `dateUpdated` datetime(0) NOT NULL,
  `uid` char(36) NOT NULL DEFAULT '0',
  `language` varchar(16) NOT NULL,
  `translation` text
) CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB
```

This is similar to the Laravel workaround described here: https://github.com/laravel/framework/issues/33238#issuecomment-648071415