### PR TITLE
Do not export messages in missing site locales

### DIFF
--- a/src/services/SourceMessageService.php
+++ b/src/services/SourceMessageService.php
@@ -29,6 +29,9 @@ class SourceMessageService extends Component
         foreach ($groups as $group) {
             $languages = [];
             foreach ($group as $item) {
+                if (!in_array($item['language'], $siteLocales)) {
+                    continue;
+                }
                 $languages[$item['language']] = $item['translation'];
             }
             if (count($languages) < count($siteLocales)) {


### PR DESCRIPTION
I had a site with a specific locale and I deleted it after a while, but the translations remained in the export table, causing the cells to shift. So here's a small edit to fix it.