### PR TITLE
Allow message strings to be excluded from being added automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can either go the **settings page** or create a file `translations-admin.php
 - **Categories**: Choose the source message categories you want to have in your database and control panel.
 - **Add missing translations**: Controls whether missing translations are automatically added to the database when a page is visited.
 - **Add missing translations for site request only**: Controls whether missing translations are only added when the request is from the site.
+- **Excluded Messages**: Messages that should not be added to the database, identified by the start of the string (basic matching, no regex — see example).
 
 Config file example:
 ```
@@ -66,7 +67,11 @@ return [
         ['category' => 'app']
     ],
     'addMissingTranslations' => false,
-    'addMissingSiteRequestOnly' => false
+    'addMissingSiteRequestOnly' => false,
+     'excludedMessages' => [
+        'Submission triggered for',
+        'Submission marked as spam'
+    ]
 ];
 ```
 

--- a/src/Translate.php
+++ b/src/Translate.php
@@ -227,6 +227,14 @@ class Translate extends Plugin
                     return;
                 }
 
+                foreach ($this->settings->getExcludedMessages() as $excludedMessagePattern) {
+                    if (str_contains($event->message, $excludedMessagePattern)) {
+                        Craft::getLogger()->log("Excluded translation message: {$event->message} because of message pattern {$excludedMessagePattern}", Logger::LEVEL_INFO, 'translations');
+                        return;
+                    }
+                }
+
+
                 $sourceMessage = SourceMessage::find()
                     ->where(array(DbHelper::caseSensitiveComparisonString('message') => $event->message, 'category' => $event->category))
                     ->one();

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -10,6 +10,7 @@ class Settings extends Model
     public $categories = [['category' => 'site']];
     public $addMissingTranslations = true;
     public $addMissingSiteRequestOnly = true;
+    public $excludedMessages = [];
 
     public function getCategories()
     {
@@ -22,5 +23,10 @@ class Settings extends Model
             }
         }
         return $cats;
+    }
+
+    public function getExcludedMessages()
+    {
+        return $this->excludedMessages;
     }
 }


### PR DESCRIPTION
This is a basic solution for the problem outlined in https://github.com/MutationDigitale/craft3-translate/issues/66

Please note that this is only a simple draft, could also be extended with Regex Patterns. Did the job in my case.

@smcyr — it would be great if you could double check this, i didn't do very extensive testing, just for a single use case.