### PR TITLE
Fix request check

### DIFF
--- a/src/Translate.php
+++ b/src/Translate.php
@@ -223,7 +223,7 @@ class Translate extends Plugin
                     return;
                 }
 
-                if (!Craft::$app->request->isSiteRequest && $this->settings->addMissingSiteRequestOnly) {
+                if (!(Craft::$app->has('request', true) && Craft::$app->request->isSiteRequest) && $this->settings->addMissingSiteRequestOnly) {
                     return;
                 }
 


### PR DESCRIPTION
Fixes request errors when testing with Codeception:

```
  | 2025-10-02 09:03:19 UTC | [yii\base\ErrorException] Undefined property: craft\web\Application::$request
  | 2025-10-02 09:03:19 UTC | #1  /app/user/vendor/craftcms/cms/src/web/ErrorHandler.php:115
  | 2025-10-02 09:03:19 UTC | #2  /app/user/vendor/mutation/translate/src/Translate.php:226
  | 2025-10-02 09:03:19 UTC | #3  mutation\translate\Translate->mutation\translate\{closure}
  | 2025-10-02 09:03:19 UTC | #4  /app/user/vendor/yiisoft/yii2/base/Event.php:312
  | 2025-10-02 09:03:19 UTC | #5  /app/user/vendor/yiisoft/yii2/base/Component.php:654
  | 2025-10-02 09:03:19 UTC | #6  /app/user/vendor/yiisoft/yii2/i18n/MessageSource.php:117
  | 2025-10-02 09:03:19 UTC | #7  /app/user/vendor/yiisoft/yii2/i18n/MessageSource.php:87
  | 2025-10-02 09:03:19 UTC | #8  /app/user/vendor/yiisoft/yii2/i18n/I18N.php:90
  | 2025-10-02 09:03:19 UTC | #9  /app/user/vendor/craftcms/cms/src/i18n/I18N.php:329
  | 2025-10-02 09:03:19 UTC | #10 /app/user/vendor/yiisoft/yii2/BaseYii.php:537
```